### PR TITLE
Automatic GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # alpine-pkg-php5-memcached
 
+[![CircleCI](https://img.shields.io/circleci/project/sgerrand/alpine-pkg-php5-memcached/master.svg)](https://circleci.com/gh/sgerrand/alpine-pkg-php5-memcached)
+
 This is the [PHP driver for Memcached][php-memcached] as a Alpine Linux package.
+
+## Releases
+
+See the [releases page](https://github.com/sgerrand/alpine-pkg-php5-memcached/releases) for the latest
+download links.
+
+## Installing
+
+The current installation method for these packages is to pull them in using
+`wget` or `curl` and install the local file with `apk`:
+
+    apk --no-cache add ca-certificates
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-php5-memcached/master/sgerrand.rsa.pub
+    wget https://github.com/sgerrand/alpine-pkg-php5-memcached/releases/download/2.2.0-r0/php5-memcached-2.2.0-r0.apk
+    apk add php5-memcached-2.2.0-r0.apk
 
 [php-mongo]: https://pecl.php.net/memcached

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ The current installation method for these packages is to pull them in using
     wget https://github.com/sgerrand/alpine-pkg-php5-memcached/releases/download/2.2.0-r0/php5-memcached-2.2.0-r0.apk
     apk add php5-memcached-2.2.0-r0.apk
 
-[php-mongo]: https://pecl.php.net/memcached
+[php-memcached]: https://pecl.php.net/memcached

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
 
 dependencies:
   pre:
+    - git fetch --tags
+    - go get github.com/tcnksm/ghr
     - mkdir packages
     - echo -e "$RSA_PUBLIC_KEY" > packages/sgerrand.rsa.pub
   override:
@@ -16,3 +18,17 @@ dependencies:
 test:
   override:
     - docker run -it -v $(pwd)/packages:/packages alpine:3.4 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
+
+deployment:
+  release:
+    tag: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
+    owner: sgerrand
+    commands:
+      - ghr -u sgerrand $CIRCLE_TAG packages/
+      - ghr -u sgerrand $CIRCLE_TAG packages/builder/x86_64
+  master:
+    branch: master
+    owner: sgerrand
+    commands:
+      - ghr -u sgerrand --prerelease --delete unreleased packages
+      - ghr -u sgerrand --prerelease unreleased packages/builder/x86_64


### PR DESCRIPTION
💁  Having build artifacts only available on CircleCI makes it more difficult to install them. Automatically creating releases close to the source code and attaching the build artifacts to them will improve the installation process for consumers of these packages.
